### PR TITLE
Fix zoom scroll issue

### DIFF
--- a/src/sticky-sidebar.js
+++ b/src/sticky-sidebar.js
@@ -244,7 +244,11 @@ const StickySidebar = (() => {
         var dims = this.dimensions;
   
         dims.sidebarLeft = StickySidebar.offsetRelative(this.sidebar).left;
-  
+
+        if (document.width > window.innerWidth) {
+            dims.sidebarLeft = dims.sidebarLeft + document.body.scrollLeft;
+        }
+
         dims.viewportTop    = document.documentElement.scrollTop || document.body.scrollTop;
         dims.viewportBottom = dims.viewportTop + dims.viewportHeight;
         dims.viewportLeft   = document.documentElement.scrollLeft || document.body.scrollLeft;


### PR DESCRIPTION
This PR fixes an issue related to zoom state. When you will try to scroll page with zoomed page on an device with touch screen, you'll get shifted sticky area.