### PR TITLE
Don't release stickyness if window width is equal to minWidth

### DIFF
--- a/src/sticky-sidebar.js
+++ b/src/sticky-sidebar.js
@@ -500,7 +500,7 @@ const StickySidebar = (() => {
        */
       _widthBreakpoint(){
   
-        if( window.innerWidth <= this.options.minWidth ){
+        if( window.innerWidth < this.options.minWidth ){
           this._breakpoint = true;
           this.affixedType = 'STATIC';
   


### PR DESCRIPTION
Sidebar should still be classed as sticky if the window width is equal to the `minWidth` option